### PR TITLE
it_freelance_CSS_240124"

### DIFF
--- a/src/_develop/_style/top.scss
+++ b/src/_develop/_style/top.scss
@@ -1177,8 +1177,6 @@ body {
 		margin-top: 40px;
 		text-align: center;
 		width: 100%;
-		// position: relative;
-		// z-index: 1;
 		@include mq(sp) {
 			height: 375px;
 			margin-top: 0;
@@ -1217,12 +1215,32 @@ body {
 		margin-top: 64px;
 	}
 	&_list {
-		display: flex;
+		display: grid;
+		gap: 20px; 
+		grid-template-columns: repeat(3, 1fr);
 		margin: 0 auto;
 		margin-top: 40px;
+		width: min(100%, 890px);
+		@include mq(tab) {
+			grid-template-columns: repeat(2, 1fr);
+			margin-top: 40px;
+			padding: 0 16px;
+			width: max(100%, 736px);
+		}
+		@include mq(sp) {
+			width: max(100%, 375px);
+		}
 		&Item {
+			text-align: center;
 			&_img {
-				width: 100%;
+				height: auto;
+				width: min(100%, 283.33px);
+				@include mq(tab) {
+					width: min(100%, 358px);
+				}
+				@include mq(sp) {
+					width: min(100%, 161.5px);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
[内容]scss修正 instagramデザイン 20240124_12:42

## 変更の概要

* instagramデザイン修正


## なぜこの変更をするのか

* デザイン通り表示させる為


## 変更内容

* gap/gridにてデザイン修正
* レスポンシブ対応


## 備考

* tab表示は2列に変更致しました。